### PR TITLE
Remove react-query usage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@tanstack/react-query": "^5.17.0",
         "prop-types": "^15.8.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -1215,32 +1214,6 @@
       "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@tanstack/query-core": {
-      "version": "5.81.5",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.81.5.tgz",
-      "integrity": "sha512-ZJOgCy/z2qpZXWaj/oxvodDx07XcQa9BF92c0oINjHkoqUPsmm3uG08HpTaviviZ/N9eP1f9CM7mKSEkIo7O1Q==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
-      }
-    },
-    "node_modules/@tanstack/react-query": {
-      "version": "5.81.5",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.81.5.tgz",
-      "integrity": "sha512-lOf2KqRRiYWpQT86eeeftAGnjuTR35myTP8MXyvHa81VlomoAWNEd8x5vkcAfQefu0qtYCvyqLropFZqgI2EQw==",
-      "license": "MIT",
-      "dependencies": {
-        "@tanstack/query-core": "5.81.5"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
-      },
-      "peerDependencies": {
-        "react": "^18 || ^19"
-      }
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "test": "echo 'No tests yet - ready for Jest/Vitest setup'"
   },
   "dependencies": {
-    "@tanstack/react-query": "^5.17.0",
     "prop-types": "^15.8.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,8 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-// import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
 
 import App from './App';
 import GlobalStyles from './styles/GlobalStyles';
@@ -10,17 +8,6 @@ import { AppProvider } from './contexts/AppContext';
 import { ErrorBoundary } from './components/common';
 import PerformanceMonitor from './components/common/PerformanceMonitor';
 
-// Create a client for React Query
-const queryClient = new QueryClient({
-  defaultOptions: {
-    queries: {
-      refetchOnWindowFocus: false,
-      retry: 1,
-      staleTime: 5 * 60 * 1000, // 5 minutes
-      gcTime: 10 * 60 * 1000, // 10 minutes (ранее cacheTime)
-    },
-  },
-});
 
 const handleGlobalError = (error, errorInfo, errorId) => {
   console.error('🚨 Global Error Caught:', { error, errorInfo, errorId });
@@ -37,14 +24,11 @@ root.render(
   <React.StrictMode>
     <ErrorBoundary showDetails={process.env.NODE_ENV === 'development'} onError={handleGlobalError}>
       <BrowserRouter>
-        <QueryClientProvider client={queryClient}>
-          <AppProvider>
-            <PerformanceMonitor enabled={process.env.NODE_ENV === 'development'} />
-            <GlobalStyles />
-            <App />
-            {/* {process.env.NODE_ENV === 'development' && <ReactQueryDevtools />} */}
-          </AppProvider>
-        </QueryClientProvider>
+        <AppProvider>
+          <PerformanceMonitor enabled={process.env.NODE_ENV === 'development'} />
+          <GlobalStyles />
+          <App />
+        </AppProvider>
       </BrowserRouter>
     </ErrorBoundary>
   </React.StrictMode>,


### PR DESCRIPTION
## Summary
- drop `@tanstack/react-query`
- rewrite API hooks to use `fetch` + `useEffect`
- simplify main entrypoint without `QueryClientProvider`

## Testing
- `npm run lint` *(fails: 762 problems)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6866393271c88330857f24d26139e69d