### PR TITLE
Remove price display from wizard navigation buttons

### DIFF
--- a/src/screens/ConfirmationScreen.jsx
+++ b/src/screens/ConfirmationScreen.jsx
@@ -686,7 +686,7 @@ function ConfirmationScreen() {
               style={{ opacity: isFormValid() ? 1 : 0.5 }}
               onClick={handleConfirm}
             >
-              <div>Подтвердить запись • {getTotalPrice()} ₽</div>
+              <div>Подтвердить запись</div>
             </ConfirmButton>
           </ButtonContainer>
 

--- a/src/screens/ServicesScreen.jsx
+++ b/src/screens/ServicesScreen.jsx
@@ -906,7 +906,7 @@ const ServicesScreen = () => {
             <ButtonContainer>
               <PrimaryButton onClick={handleContinue}>
                 <ButtonContent>
-                  <ButtonText>Продолжить • {getTotalPrice().toLocaleString()} ₽</ButtonText>
+                  <ButtonText>Продолжить</ButtonText>
                 </ButtonContent>
               </PrimaryButton>
             </ButtonContainer>


### PR DESCRIPTION
## Summary
- remove total price from Continue button
- drop price from confirm booking button

## Testing
- `npm run lint` *(fails: no-unused-vars and other lint errors)*
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68666489a0e48330a4c7622c9f39afbb